### PR TITLE
Deleted helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# Pwnagotchi w/ Waveshare V3 & Pisugar 2/3 Screen Inversion Scripts
+# Pwnagotchi w/ Waveshare V3 & Pisugar 2/3 Screen Inversion Script
 
 ## Overview
-This repository contains two Bash scripts for Pwnagotchi devices equipped with a Waveshare V3 screen and a PiSugar 2 or 3 battery. These scripts enable users to invert the screen colors of their Pwnagotchi, on the go, by pressing or holding a button on the PiSugar battery.
+This repository contains a Bash script designed for Pwnagotchi devices equipped with a Waveshare V3 screen and a PiSugar 2 or 3 battery. This script enables users to invert the screen colors of their Pwnagotchi, on the go, by pressing or holding the *custom* button on the PiSugar battery.
 
 ## Prerequisites
 - Configured Pwnagotchi device
-- Waveshare V3 screen
+- Waveshare V3 screen  (Needs to be tested on V2)
 - PiSugar 2 or 3 battery
 
 ## Installation
 
 ### Cloning the Repository
-First, clone this repository to your Pwnagotchi device in the home directory:
+First, clone this repository to your Pwnagotchi device in its home directory and navigate to the project directory:
 ```
 cd ~
 git clone https://github.com/tPayne0647/pwnagotchi_screen_color_invert.git
@@ -19,32 +19,24 @@ cd pwnagotchi_screen_color_invert
 ```
 
 ### Setting File Permissions
-After cloning the repository, you need to set the execute permissions for the scripts. Run the following commands:
+After cloning the repository, you need to set the execute permissions by running the following command:
 ```
 chmod +x invert_colors.sh
-chmod +x invert_open.sh
 ```
 
-### Script Descriptions
-
-1. **invert_colors.sh**: This script inverts the colors of the Pwnagotchi's display.
-
-
-2. **invert_open.sh**: A helper script to execute `invert_colors.sh` with the necessary permissions.
-
 ### Configuring PiSugar
-To use these scripts with your PiSugar battery, follow these steps:
+To use this script with your PiSugar battery, follow these steps:
 
 1. Access the PiSugar Web GUI on your device ` http://<your raspberry ip>:8421`
 2. Navigate to the *Custom Button Function* section where you can assign actions to button presses.
-3. Assign `/home/pi/pwnagotchi_screen_color_invert/invert_open.sh` to the desired button press. This will trigger the screen color inversion when the button is pressed.
+3. Paste `sudo /home/pi/pwnagotchi_screen_color_invert/invert_colors.sh` to the desired button press.
 
 ## Usage
-Press the configured button on your PiSugar battery to invert the screen colors of your Pwnagotchi. It will restart after a few seconds and will come back up with the colors inverted. Press the button again to restore the original colors.
+Press the configured button on your PiSugar battery to invert the screen colors of your Pwnagotchi. It will restart after a few seconds and will come back up with the colors inverted. Press the button again to restore the original colors. 
 
 ## Notes
+- Ensure that your Pwnagotchi, PiSugar and Waveshare screen are correctly set up before running the scripts.
 - The `invert_colors.sh` script creates a backup of the original `view.py` file before making changes.
-- Ensure that your Pwnagotchi and PiSugar are correctly set up.
 - The log file can be found in the project directory as `invert_colors.log` for troubleshooting.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To use this script with your PiSugar battery, follow these steps:
 3. Paste `sudo /home/pi/pwnagotchi_screen_color_invert/invert_colors.sh` to the desired button press.
 
 ## Usage
-Press the configured button on your PiSugar battery to invert the screen colors of your Pwnagotchi. It will restart after a few seconds and will come back up with the colors inverted. Press the button again to restore the original colors. 
+Press the configured button on your PiSugar battery to invert the screen colors of your Pwnagotchi. It will restart after a few seconds and will come back up with the colors inverted. Press the button again to restore the original colors.
 
 ## Notes
 - Ensure that your Pwnagotchi, PiSugar and Waveshare screen are correctly set up before running the scripts.

--- a/invert_open.sh
+++ b/invert_open.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# This script is used to run the invert_colors.sh script with sudo permissions.
-# TODO: figure out if Pisugar can run scripts with sudo permissions, making this file unnecessary.
-
-sudo /home/pi/pwnagotchi_screen_color_invert/invert_colors.sh


### PR DESCRIPTION
In testing, found out you can just simply run the script as sudo by just adding *sudo* in front of the path 😅 So the helper script is unnecessary as long as this is configured properly in PiSugar UI. 

- [x] Remove invert_open.sh
- [x] Update README.md